### PR TITLE
Fix "Device busy" issues even after closing a stream

### DIFF
--- a/v4l2py/device.py
+++ b/v4l2py/device.py
@@ -498,6 +498,11 @@ class Buffers:
             for buff in self.buffers:
                 buff.close()
             self.buffers = None
+        r = raw.v4l2_requestbuffers()
+        r.count = 0
+        r.type = self.buffer_type
+        r.memory = self.memory
+        self._ioctl(IOC.REQBUFS, r)
 
     def raw_read(self):
         buff = self.buffers[0]._v4l2_buffer()


### PR DESCRIPTION
Again, sorry to bother
This allows me to change resolutions. I need to properly close the stream to change device parameters, then open the stream again
Without this, I get the "Device busy" sort of errors.
Thank you for looking at these two 