### PR TITLE
Fix bug that makes iter_read_controls() skip many control types 

### DIFF
--- a/v4l2py/device.py
+++ b/v4l2py/device.py
@@ -279,7 +279,7 @@ def iter_read_controls(fd):
     ctrl_ext.id = nxt
     for ctrl_ext in iter_read(fd, IOC.QUERY_EXT_CTRL, ctrl_ext):
         if not (ctrl_ext.flags & raw.V4L2_CTRL_FLAG_DISABLED) and not (
-            ctrl_ext.type & raw.V4L2_CTRL_TYPE_CTRL_CLASS
+            ctrl_ext.type == raw.V4L2_CTRL_TYPE_CTRL_CLASS
         ):
             yield copy.deepcopy(ctrl_ext)
         ctrl_ext.id |= nxt


### PR DESCRIPTION
iter_read_controls() skipps many/most control types. This bug has been caused by wrongly using an integer/enum in a bitmask-style operation. Fixes otaku42/v4l2py#1.