### PR TITLE
Suggestion to make the web example work with Python < v3.10

### DIFF
--- a/examples/web/app.py
+++ b/examples/web/app.py
@@ -155,21 +155,20 @@ def cameras() -> list[Camera]:
 
 
 def buffer_to_frame_maker(format: Format, output="jpeg"):
-    match (format.pixel_format, output.lower()):
-        case (PixelFormat.JPEG | PixelFormat.MJPEG, "jpeg"):
-            return functools.partial(to_frame, type="jpeg")
-        case _:
-            return functools.partial(buffer_to_frame, format=format, output=output)
+    if ((output.lower() == "jpeg") and
+            (format.pixel_format in (PixelFormat.JPEG, PixelFormat.MJPEG))):
+        return functools.partial(to_frame, type="jpeg")
+    else:
+        return functools.partial(buffer_to_frame, format=format, output=output)
 
 
 def buffer_to_frame(data: bytes, format: Format, output="jpeg"):
-    match format.pixel_format:
-        case PixelFormat.JPEG | PixelFormat.MJPEG:
-            image = Image.open(io.BytesIO(data))
-        case PixelFormat.GREY:
-            image = Image.frombuffer("L", (format.width, format.height), data)
-        case _:
-            raise ValueError(f"unsupported pixel format {format.pixel_format}")
+    if (format.pixel_format in (PixelFormat.JPEG, PixelFormat.MJPEG)):
+        image = Image.open(io.BytesIO(data))
+    elif (format.pixel_format == PixelFormat.GREY):
+        image = Image.frombuffer("L", (format.width, format.height), data)
+    else:
+        raise ValueError(f"unsupported pixel format {format.pixel_format}")
     buff = io.BytesIO()
     image.save(buff, output)
     return to_frame(buff.getvalue(), type=output)


### PR DESCRIPTION
As it stands, the web example requires at least Python 3.10 due to the use of the `match` statement. While not as elegant, the proposed change should lower the bar down to Python 3.7, which is the declared "entry barrier" for this whole codebase.