### PR TITLE
Fix infinite recursion. Closes otaku42/v4l2py#16.

### DIFF
--- a/v4l2py/device.py
+++ b/v4l2py/device.py
@@ -583,7 +583,7 @@ def set_priority(fd, priority: Priority):
 
 def create_buffer(fd, buffer_type: BufferType, memory: Memory) -> raw.v4l2_buffer:
     """request + query buffers"""
-    return create_buffer(fd, buffer_type, memory, 1)
+    return create_buffers(fd, buffer_type, memory, 1)
 
 
 def create_buffers(

--- a/v4l2py/device.py
+++ b/v4l2py/device.py
@@ -583,7 +583,8 @@ def set_priority(fd, priority: Priority):
 
 def create_buffer(fd, buffer_type: BufferType, memory: Memory) -> raw.v4l2_buffer:
     """request + query buffers"""
-    return create_buffers(fd, buffer_type, memory, 1)
+    buffers = create_buffers(fd, buffer_type, memory, 1)
+    return buffers[0]
 
 
 def create_buffers(


### PR DESCRIPTION
The `create_buffer` helper is calling itself in the return statement, causing infinite recursion. I assume that this should be `create_buffers` (with **s**)  instead.