### PR TITLE
Add condition check

### DIFF
--- a/v4l2py/device.py
+++ b/v4l2py/device.py
@@ -1186,6 +1186,7 @@ class MenuControl(BaseMonoControl, UserDict):
             self.data = {
                 item.index: int(item.name)
                 for item in iter_read_menu(self.device._fobj, self)
+                if item.name != b''
             }
         else:
             raise TypeError(


### PR DESCRIPTION
Hi

My camera returns b'' while initialization, so I suggest a condition check.

Log with error:
```
Traceback (most recent call last):
  File "capture_video.py", line 39, in video_capture
    with Device.from_id(0) as cam:
  File "/data/camera-streamer/env/lib/python3.8/site-packages/v4l2py/device.py", line 685, in _init
    self.controls = Controls.from_device(self)
  File "/data/camera-streamer/env/lib/python3.8/site-packages/v4l2py/device.py", line 805, in from_device
    ctrl_dict[ctrl.id] = ctrl_class(device, ctrl)
  File "/data/camera-streamer/env/lib/python3.8/site-packages/v4l2py/device.py", line 1186, in __init__
    self.data = {
  File "/data/camera-streamer/env/lib/python3.8/site-packages/v4l2py/device.py", line 1187, in <dictcomp>
    item.index: int(item.name)
ValueError: invalid literal for int() with base 10: b''
```
